### PR TITLE
エラーメッセージの日本語化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,3 +64,4 @@ gem 'active_hash'
 gem 'payjp'
 gem "aws-sdk-s3", require: false
 gem 'ransack'
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
+    rails-i18n (7.0.1)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (6.0.4.4)
       actionpack (= 6.0.4.4)
       activesupport (= 6.0.4.4)
@@ -332,6 +335,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails-i18n
   ransack
   rspec-rails (~> 4.0.0)
   rubocop

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,11 +11,11 @@ class Item < ApplicationRecord
   validates :image, presence: true
   validates :name, presence: true
   validates :text, presence: true
-  validates :category_id, presence: true, numericality: { other_than: 1 }
-  validates :situation_id, presence: true, numericality: { other_than: 1 }
-  validates :delivery_charge_id, presence: true, numericality: { other_than: 1 }
-  validates :prefecture_id, presence: true, numericality: { other_than: 1 }
-  validates :delivery_time_id, presence: true, numericality: { other_than: 1 }
+  validates :category_id, presence: true, numericality: { other_than: 1, message: 'を選択して下さい' }
+  validates :situation_id, presence: true, numericality: { other_than: 1, message: 'を選択して下さい' }
+  validates :delivery_charge_id, presence: true, numericality: { other_than: 1, message: 'を選択して下さい' }
+  validates :prefecture_id, presence: true, numericality: { other_than: 1, message: 'を選択して下さい' }
+  validates :delivery_time_id, presence: true, numericality: { other_than: 1, message: 'を選択して下さい' }
   validates :price, presence: true, format: { with: /\A[\d]+\z/ }, numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999 }
   has_one :order
   has_many :comments

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,11 +11,11 @@ class Item < ApplicationRecord
   validates :image, presence: true
   validates :name, presence: true
   validates :text, presence: true
-  validates :category_id, presence: true, numericality: { other_than: 1, message: 'を選択して下さい' }
-  validates :situation_id, presence: true, numericality: { other_than: 1, message: 'を選択して下さい' }
-  validates :delivery_charge_id, presence: true, numericality: { other_than: 1, message: 'を選択して下さい' }
-  validates :prefecture_id, presence: true, numericality: { other_than: 1, message: 'を選択して下さい' }
-  validates :delivery_time_id, presence: true, numericality: { other_than: 1, message: 'を選択して下さい' }
+  validates :category_id, presence: true, numericality: { other_than: 1, message: 'を選択してください' }
+  validates :situation_id, presence: true, numericality: { other_than: 1, message: 'を選択してください' }
+  validates :delivery_charge_id, presence: true, numericality: { other_than: 1, message: 'を選択してください' }
+  validates :prefecture_id, presence: true, numericality: { other_than: 1, message: 'を選択してください' }
+  validates :delivery_time_id, presence: true, numericality: { other_than: 1, message: 'を選択してください' }
   validates :price, presence: true, format: { with: /\A[\d]+\z/ }, numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999 }
   has_one :order
   has_many :comments

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -6,7 +6,7 @@ class OrderAddress
     validates :user_id
     validates :item_id
     validates :post_code, format: {with: /\A\d{3}-\d{4}\z/}
-    validates :prefecture_id,  numericality: { other_than: 1 }
+    validates :prefecture_id,  numericality: { other_than: 1, message: 'を選択してください' }
     validates :municipalities
     validates :address
     validates :telephone_number, format: {with: /\A\d{10,11}\z/}

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module Furima36709
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
+    config.i18n.default_locale = :ja
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,7 @@ module Furima36709
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
     config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.yml').to_s]
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -9,7 +9,7 @@ ja:
         current_password: 現在のパスワード
         current_sign_in_at: 現在のログイン時刻
         current_sign_in_ip: 現在のログインIPアドレス
-        email: Eメール
+        email: メールアドレス
         encrypted_password: 暗号化パスワード
         failed_attempts: 失敗したログイン試行回数
         last_sign_in_at: 最終ログイン時刻

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,143 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: ログインもしくはアカウント登録してください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
+        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -19,6 +19,10 @@ ja:
         delivery_time_id: 発送までの日数
         price: 価格
         user: ユーザー情報
+      comment:
+        text: コメント文
+        user: ユーザー情報
+        item: 商品情報
   activemodel:
     models:
       order_address:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,10 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        nickname: ニックネーム
+        real_name_two_byte_s: お名前(全角)(名字)
+        real_name_two_byte_p: お名前(全角)(名前)
+        real_name_kana_s: お名前カナ(全角)(名字)
+        real_name_kana_p: お名前カナ(全角)(名前)
+        birthday: 生年月日

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -28,4 +28,6 @@ ja:
         municipalities: 市区町村
         address: 番地
         telephone_number: 電話番号
+        user_id: ユーザー情報
+        item_id: 商品情報
         token: カード情報

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -18,6 +18,7 @@ ja:
         prefecture_id: 発送元の地域
         delivery_time_id: 発送までの日数
         price: 価格
+        user: ユーザー情報
   activemodel:
     models:
       order_address:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -18,3 +18,14 @@ ja:
         prefecture_id: 発送元の地域
         delivery_time_id: 発送までの日数
         price: 価格
+  activemodel:
+    models:
+      order_address:
+    attributes:
+      order_address:
+        post_code: 郵便番号
+        prefecture_id: 都道府県
+        municipalities: 市区町村
+        address: 番地
+        telephone_number: 電話番号
+        token: カード情報

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -8,3 +8,13 @@ ja:
         real_name_kana_s: お名前カナ(全角)(名字)
         real_name_kana_p: お名前カナ(全角)(名前)
         birthday: 生年月日
+      item:
+        name: 商品名
+        text: 商品の説明
+        image: 画像
+        category_id: カテゴリー
+        situation_id: 商品の状態
+        delivery_charge_id: 配送料の負担
+        prefecture_id: 発送元の地域
+        delivery_time_id: 発送までの日数
+        price: 価格

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -15,17 +15,17 @@ RSpec.describe Comment, type: :model do
       it 'コメント文が空では投稿できない' do
         @comment.text = ''
         @comment.valid?
-        expect(@comment.errors.full_messages).to include("Text can't be blank")
+        expect(@comment.errors.full_messages).to include("コメント文を入力してください")
       end
       it 'ユーザー情報が紐付いていないと投稿できない' do
         @comment.user = nil
         @comment.valid?
-        expect(@comment.errors.full_messages).to include("User must exist")
+        expect(@comment.errors.full_messages).to include("ユーザー情報を入力してください")
       end
       it '商品情報が紐付いていないと投稿できない' do
         @comment.item = nil
         @comment.valid?
-        expect(@comment.errors.full_messages).to include("Item must exist")
+        expect(@comment.errors.full_messages).to include("商品情報を入力してください")
       end
     end
   end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -15,92 +15,92 @@ RSpec.describe Item, type: :model do
       it '商品画像が空では出品できない' do
         @item.image = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Image can't be blank")
+        expect(@item.errors.full_messages).to include("画像を入力してください")
       end
       it '商品名が空では出品できない' do
         @item.name = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Name can't be blank")
+        expect(@item.errors.full_messages).to include("商品名を入力してください")
       end
       it '商品名の説明が空では出品できない' do
         @item.text = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Text can't be blank")
+        expect(@item.errors.full_messages).to include("商品の説明を入力してください")
       end
       it 'カテゴリーが未選択だと出品できない' do
         @item.category_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category can't be blank")
+        expect(@item.errors.full_messages).to include("カテゴリーを選択してください")
       end
       it 'カテゴリーが「---」選択だと出品できない' do
         @item.category_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category must be other than 1")
+        expect(@item.errors.full_messages).to include("カテゴリーを選択してください")
       end
       it '商品の状態が未選択だと出品できない' do
         @item.situation_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Situation can't be blank")
+        expect(@item.errors.full_messages).to include("商品の状態を選択してください")
       end
       it '商品の状態が「---」選択だと出品できない' do
         @item.situation_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Situation must be other than 1")
+        expect(@item.errors.full_messages).to include("商品の状態を選択してください")
       end
       it '配送料の負担が未選択だと出品できない' do
         @item.delivery_charge_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery charge can't be blank")
+        expect(@item.errors.full_messages).to include("配送料の負担を選択してください")
       end
       it '配送料の負担が「---」選択だと出品できない' do
         @item.delivery_charge_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery charge must be other than 1")
+        expect(@item.errors.full_messages).to include("配送料の負担を選択してください")
       end
       it '発送元の地域が未選択だと出品できない' do
         @item.prefecture_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Prefecture can't be blank")
+        expect(@item.errors.full_messages).to include("発送元の地域を選択してください")
       end
       it '発送元の地域が「---」選択だと出品できない' do
         @item.prefecture_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Prefecture must be other than 1")
+        expect(@item.errors.full_messages).to include("発送元の地域を選択してください")
       end
       it '発送までの日数が未選択だと出品できない' do
         @item.delivery_time_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery time can't be blank")
+        expect(@item.errors.full_messages).to include("発送までの日数を選択してください")
       end
       it '発送までの日数が「---」選択だと出品できない' do
         @item.delivery_time_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery time must be other than 1")
+        expect(@item.errors.full_messages).to include("発送までの日数を選択してください")
       end
       it '価格の情報が空だと出品できない' do
         @item.price = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price can't be blank")
+        expect(@item.errors.full_messages).to include("価格を入力してください")
       end
       it '価格が¥300未満だと出品できない' do
         @item.price = 299
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be greater than or equal to 300")
+        expect(@item.errors.full_messages).to include("価格は300以上の値にしてください")
       end
       it '価格が¥10,000,000以上だと出品できない' do
         @item.price = 10000000
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be less than or equal to 9999999")
+        expect(@item.errors.full_messages).to include("価格は9999999以下の値にしてください")
       end
       it '価格の情報が全角文字で記入されていると出品できない' do
         @item.price = "３００"
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include("価格は数値で入力してください")
       end
       it 'ユーザー情報が紐付いていないと出品できない' do
         @item.user = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("User must exist")
+        expect(@item.errors.full_messages).to include("Userを入力してください")
       end
     end
   end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Item, type: :model do
       it 'ユーザー情報が紐付いていないと出品できない' do
         @item.user = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Userを入力してください")
+        expect(@item.errors.full_messages).to include("ユーザー情報を入力してください")
       end
     end
   end

--- a/spec/models/order_address_spec.rb
+++ b/spec/models/order_address_spec.rb
@@ -22,77 +22,77 @@ RSpec.describe OrderAddress, type: :model do
       it '郵便番号が空だと保存できない' do
         @order_address.post_code = ''
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include("Post code can't be blank")
+        expect(@order_address.errors.full_messages).to include("郵便番号を入力してください")
       end
       it '郵便番号にハイフンが入っていないと保存できない' do
         @order_address.post_code = '1234567'
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include("Post code is invalid")
+        expect(@order_address.errors.full_messages).to include("郵便番号は不正な値です")
       end
       it '郵便番号が全角文字が記入されていると保存できない' do
         @order_address.post_code = '１23-4567'
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include("Post code is invalid")
+        expect(@order_address.errors.full_messages).to include("郵便番号は不正な値です")
       end
       it '都道府県が空だと保存できない' do
         @order_address.prefecture_id = ''
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include("Prefecture can't be blank")
+        expect(@order_address.errors.full_messages).to include("都道府県を選択してください")
       end
       it '都道府県が「---」選択だと保存できない' do
         @order_address.prefecture_id = 1
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include("Prefecture must be other than 1")
+        expect(@order_address.errors.full_messages).to include("都道府県を選択してください")
       end
       it '市町村が空だと保存できない' do
         @order_address.municipalities = ''
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include("Municipalities can't be blank")
+        expect(@order_address.errors.full_messages).to include("市区町村を入力してください")
       end
       it '番地が空だと保存できない' do
         @order_address.address = ''
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include("Address can't be blank")
+        expect(@order_address.errors.full_messages).to include("番地を入力してください")
       end
       it '電話番号が空だと保存できない' do
         @order_address.telephone_number = ''
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include("Telephone number can't be blank")
+        expect(@order_address.errors.full_messages).to include("電話番号を入力してください")
       end
       it '電話番号にハイフンが入っていると保存できない' do
         @order_address.telephone_number = '090-12345678'
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include("Telephone number is invalid")
+        expect(@order_address.errors.full_messages).to include("電話番号は不正な値です")
       end
       it '電話番号が9桁以下だと保存できない' do
         @order_address.telephone_number = '090123456'
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include("Telephone number is invalid")
+        expect(@order_address.errors.full_messages).to include("電話番号は不正な値です")
       end
       it '電話番号が12桁以上だと保存できない' do
         @order_address.telephone_number = '090123456789'
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include("Telephone number is invalid")
+        expect(@order_address.errors.full_messages).to include("電話番号は不正な値です")
       end
       it '電話番号が全角文字で記入されていると保存できない' do
         @order_address.telephone_number = '０9012345678'
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include("Telephone number is invalid")
+        expect(@order_address.errors.full_messages).to include("電話番号は不正な値です")
       end
       it 'ユーザー情報が紐付いていないと保存できない' do
         @order_address.user_id = nil
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include("User can't be blank")
+        expect(@order_address.errors.full_messages).to include("ユーザー情報を入力してください")
       end
       it '商品情報が紐付いていないと保存できない' do
         @order_address.item_id = nil
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include("Item can't be blank")
+        expect(@order_address.errors.full_messages).to include("商品情報を入力してください")
       end
       it 'tokenが空だと保存できない' do
         @order_address.token = nil
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include("Token can't be blank")
+        expect(@order_address.errors.full_messages).to include("カード情報を入力してください")
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,102 +15,102 @@ RSpec.describe User, type: :model do
       it 'nicknameが空では登録できない' do
         @user.nickname = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Nickname can't be blank"
+        expect(@user.errors.full_messages).to include "ニックネームを入力してください"
       end
       it 'emailが空では登録できない' do
         @user.email = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Email can't be blank"
+        expect(@user.errors.full_messages).to include "メールアドレスを入力してください"
       end
       it '重複したemailが存在する場合登録できない' do
         @user.save
         another_user = FactoryBot.build(:user)
         another_user.email = @user.email
         another_user.valid?
-        expect(another_user.errors.full_messages).to include "Email has already been taken"
+        expect(another_user.errors.full_messages).to include "メールアドレスはすでに存在します"
       end
       it 'emailに@が無ければ登録できない' do
         @user.email = 'test'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Email is invalid"
+        expect(@user.errors.full_messages).to include "メールアドレスは不正な値です"
       end
       it 'passwordが空では登録できない' do
         @user.password = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Password can't be blank"
+        expect(@user.errors.full_messages).to include "パスワードを入力してください"
       end
       it 'passwordが5文字以下では登録できない' do
         @user.password = '00000'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Password is too short (minimum is 6 characters)"
+        expect(@user.errors.full_messages).to include "パスワードは6文字以上で入力してください"
       end
       it 'passwordが英字のみでは登録できない' do
         @user.password = 'abcdef'
         @user.password_confirmation = 'abcdef'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Password is invalid"
+        expect(@user.errors.full_messages).to include "パスワードは不正な値です"
       end
       it 'passwordが数字のみでは登録できない' do
         @user.password = '123456'
         @user.password_confirmation = '123456'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Password is invalid"
+        expect(@user.errors.full_messages).to include "パスワードは不正な値です"
       end
       it 'passwordに全角文字が含まれている場合登録できない' do
         @user.password = 'ａbc123'
         @user.password_confirmation = 'ａbc123'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Password is invalid"
+        expect(@user.errors.full_messages).to include "パスワードは不正な値です"
       end
       it 'passwordとpassword_confirmationが不一致では登録できない' do
         @user.password_confirmation = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Password confirmation doesn't match Password"
+        expect(@user.errors.full_messages).to include "パスワード（確認用）とパスワードの入力が一致しません"
       end
       it 'お名前(姓)(全角)が空では登録できない' do
         @user.real_name_two_byte_s = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Real name two byte s can't be blank"
+        expect(@user.errors.full_messages).to include "お名前(全角)(名字)を入力してください"
       end
       it 'お名前(名)(全角)が空では登録できない' do
         @user.real_name_two_byte_p = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Real name two byte p can't be blank"
+        expect(@user.errors.full_messages).to include "お名前(全角)(名前)を入力してください"
       end
       it 'お名前(姓)(全角)に半角文字が含まれている場合登録できない' do
         @user.real_name_two_byte_s = 'ﾔﾏﾀﾞ'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Real name two byte s is invalid"
+        expect(@user.errors.full_messages).to include "お名前(全角)(名字)は不正な値です"
       end
       it 'お名前(名)(全角)に半角文字が含まれている場合登録できない' do
         @user.real_name_two_byte_p = 'ﾘｸﾀﾛｳ'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Real name two byte p is invalid"
+        expect(@user.errors.full_messages).to include "お名前(全角)(名前)は不正な値です"
       end
       it 'お名前カナ(姓)(全角)が空では登録できない' do
         @user.real_name_kana_s = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Real name kana s can't be blank"
+        expect(@user.errors.full_messages).to include "お名前カナ(全角)(名字)を入力してください"
       end
       it 'お名前カナ(名)(全角)が空では登録できない' do
         @user.real_name_kana_p = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Real name kana p can't be blank"
+        expect(@user.errors.full_messages).to include "お名前カナ(全角)(名前)を入力してください"
       end
       it 'お名前カナ(姓)(全角)にカタカナ以外の文字が含まれている場合登録できない' do
         @user.real_name_kana_s = '山田'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Real name kana s is invalid"
+        expect(@user.errors.full_messages).to include "お名前カナ(全角)(名字)は不正な値です"
       end
       it 'お名前カナ(名)(全角)にカタカナ以外の文字が含まれている場合登録できない' do
         @user.real_name_kana_p = '陸太郎'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Real name kana p is invalid"
+        expect(@user.errors.full_messages).to include "お名前カナ(全角)(名前)は不正な値です"
       end
       it '生年月日が空では登録できない' do
         @user.birthday = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Birthday can't be blank"
+        expect(@user.errors.full_messages).to include "生年月日を入力してください"
       end
     end
   end


### PR DESCRIPTION
# What
エラーメッセージを、英語から日本語に変換
# Why
フリーマーケットサイトを再現するために必要な、日本語表記を実装する為